### PR TITLE
feat: add PDF parsing and chunking pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,15 @@
-app.db
-*.db
-venv/
-.venv/
+# Python
 __pycache__/
+*.pyc
+
+# Virtual environment
+.venv/
+
+# Environment variables
 .env
+
+# Database
+*.db
+
+# Uploaded files
+storage/documents/

--- a/db/init_db.py
+++ b/db/init_db.py
@@ -1,7 +1,11 @@
 # db/init_db.py
 from db.base import Base
 from db.session import engine
-import models # noqa: F401 (모델 impport로 테이블 등록)
+
+from models.conversation import Conversation
+from models.message import Message
+from models.document import Document
+from models.document_chunk import DocumentChunk
 
 def init_db() -> None:
     Base.metadata.create_all(bind=engine)

--- a/models/document.py
+++ b/models/document.py
@@ -2,7 +2,7 @@
 from datetime import datetime
 
 from sqlalchemy import DateTime, String
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from db.base import Base
 
@@ -21,4 +21,9 @@ class Document(Base):
         default=datetime.utcnow,
         onupdate=datetime.utcnow,
         nullable=False,
+    )
+    chunks = relationship(
+        "DocumentChunk",
+        back_populates="document",
+        cascade="all, delete-orphan",
     )

--- a/models/document_chunk.py
+++ b/models/document_chunk.py
@@ -1,0 +1,28 @@
+# models/document_chunk.py
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, Text, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from db.base import Base
+
+class DocumentChunk(Base):
+    __tablename__ = "document_chunks"
+
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    document_id: Mapped[int] = mapped_column(
+        ForeignKey("documents.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    chunk_index: Mapped[int] = mapped_column(Integer, nullable=False)
+    page_number: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+
+    document = relationship("Document", back_populates="chunks")

--- a/repositories/document_chunk_repo.py
+++ b/repositories/document_chunk_repo.py
@@ -1,0 +1,42 @@
+# repositories/document_chunk_repo.py
+from sqlalchemy.orm import Session
+
+from models.document_chunk import DocumentChunk
+
+class DocumentChunkRepository:
+    def create_many(
+            self,
+            db: Session,
+            *,
+            document_id: int,
+            chunks: list[dict],
+    ) -> list[DocumentChunk]:
+        chunk_objects = [
+            DocumentChunk(
+            document_id=document_id,
+                chunk_index=chunk["chunk_index"],
+                page_number=chunk.get("page_number"),
+                content=chunk["content"],
+            )
+            for chunk in chunks
+        ]
+
+        db.add_all(chunk_objects)
+        db.commit()
+
+        for chunk_obj in chunk_objects:
+            db.refresh(chunk_obj)
+
+        return chunk_objects
+
+    def list_by_document_id(self, db: Session, document_id: int) -> list[DocumentChunk]:
+        return (
+            db.query(DocumentChunk)
+            .filter(DocumentChunk.document_id == document_id)
+            .order_by(DocumentChunk.chunk_index.asc())
+            .all()
+        )
+
+    def delete_by_document_id(self, db: Session, document_id: int) -> None:
+        db.query(DocumentChunk).filter(DocumentChunk.document_id == document_id).delete()
+        db.commit()

--- a/repositories/document_repo.py
+++ b/repositories/document_repo.py
@@ -3,22 +3,35 @@ from sqlalchemy.orm import Session
 
 from models.document import Document
 
-def create_document(
+
+class DocumentRepository:
+    def create_document(
+        self,
         db: Session,
+        *,
         filename: str,
         stored_filename: str,
         file_path: str,
         file_type: str,
         status: str = "uploaded",
-) -> Document:
-    document = Document(
-        filename=filename,
-        stored_filename=stored_filename,
-        file_path=file_path,
-        file_type=file_type,
-        status=status,
-    )
-    db.add(document)
-    db.commit()
-    db.refresh(document)
-    return document
+    ) -> Document:
+        document = Document(
+            filename=filename,
+            stored_filename=stored_filename,
+            file_path=file_path,
+            file_type=file_type,
+            status=status,
+        )
+        db.add(document)
+        db.commit()
+        db.refresh(document)
+        return document
+
+    def get_document_by_id(self, db: Session, document_id: int) -> Document | None:
+        return db.query(Document).filter(Document.id == document_id).first()
+
+    def update_document_status(self, db: Session, document: Document, status: str) -> Document:
+        document.status = status
+        db.commit()
+        db.refresh(document)
+        return document

--- a/services/chunking_service.py
+++ b/services/chunking_service.py
@@ -1,0 +1,53 @@
+# services/chunking_service.py
+class ChunkingService:
+    def __init__(self, chunk_size: int = 1000, chunk_overlap: int = 150):
+        if chunk_overlap >= chunk_size:
+            raise ValueError("chunk_overlap must be smaller than chunk_size")
+
+        self.chunk_size = chunk_size
+        self.chunk_overlap = chunk_overlap
+
+    def create_chunks(self, pages: list[dict]) -> list[dict]:
+        chunks: list[dict] = []
+        chunk_index = 0
+
+        for page in pages:
+            page_number = page["page_number"]
+            text = page["text"]
+
+            page_chunks = self._split_text(text)
+
+            for content in page_chunks:
+                chunks.append(
+                    {
+                        "chunk_index": chunk_index,
+                        "page_number": page_number,
+                        "content": content,
+                    }
+                )
+                chunk_index += 1
+
+        return chunks
+
+    def _split_text(self, text: str) -> list[str]:
+        text = text.strip()
+        if not text:
+            return []
+
+        chunks: list[str] = []
+        start = 0
+        text_length = len(text)
+
+        while start < text_length:
+            end = start + self.chunk_size
+            chunk = text[start:end].strip()
+
+            if chunk:
+                chunks.append(chunk)
+
+            if end >= text_length:
+                break
+
+            start = end - self.chunk_overlap
+
+        return chunks

--- a/services/document_parser_service.py
+++ b/services/document_parser_service.py
@@ -1,0 +1,28 @@
+# services/document_parser_service.py
+from pypdf import PdfReader
+
+class DocumentParserService:
+    def extract_pdf_pages(self, file_path: str) -> list[dict]:
+        reader = PdfReader(file_path)
+        pages: list[dict] = []
+
+        for index, page in enumerate(reader.pages, start=1):
+            text = page.extract_text() or ""
+            cleaned_text = self._clean_text(text)
+
+            if not cleaned_text:
+                continue
+
+            pages.append(
+                {
+                    "page_number": index,
+                    "text": cleaned_text,
+                }
+            )
+
+        return pages
+
+    def _clean_text(self, text: str) -> str:
+        lines = [line.strip() for line in text.splitlines()]
+        non_empty_lines = [line for line in lines if line]
+        return "\n".join(non_empty_lines).strip()

--- a/services/document_service.py
+++ b/services/document_service.py
@@ -6,9 +6,17 @@ from fastapi import HTTPException, UploadFile, status
 from sqlalchemy.orm import Session
 
 from core.settings import settings
-from repositories.document_repo import create_document
+from repositories.document_repo import DocumentRepository
+from repositories.document_chunk_repo import DocumentChunkRepository
+from services.document_parser_service import DocumentParserService
+from services.chunking_service import ChunkingService
 
 ALLOWED_EXTENSIONS = {".pdf"}
+
+document_repo = DocumentRepository()
+document_chunk_repo = DocumentChunkRepository()
+document_parser_service = DocumentParserService()
+chunking_service = ChunkingService()
 
 
 def upload_document(db: Session, file: UploadFile):
@@ -37,7 +45,7 @@ def upload_document(db: Session, file: UploadFile):
         with file_path.open("wb") as buffer:
             buffer.write(file_bytes)
 
-        document = create_document(
+        document = document_repo.create_document(
             db=db,
             filename=file.filename,
             stored_filename=stored_filename,
@@ -45,6 +53,20 @@ def upload_document(db: Session, file: UploadFile):
             file_type=file.content_type or "application/pdf",
             status="uploaded",
         )
+
+        document_repo.update_document_status(db, document, "processing")
+
+        pages = document_parser_service.extract_pdf_pages(str(file_path))
+        chunks = chunking_service.create_chunks(pages)
+
+        if chunks:
+            document_chunk_repo.create_many(
+                db=db,
+                document_id=document.id,
+                chunks=chunks,
+            )
+
+        document = document_repo.update_document_status(db, document, "processed")
         return document
 
     except Exception as e:


### PR DESCRIPTION
##  Summary

Add PDF text extraction and chunking pipeline for uploaded documents.

## Changes
- add `DocumentChunk` model
- add document chunk repository
- add PDF text extraction service
- add text chunking service
- connect parsing and chunking flow in `document_service`
- update document status during processing
- store generated chunks in SQLite

## Result
- uploaded PDF files are parsed into text
- extracted text is split into chunks
- generated chunks are stored in `document_chunks`
- document status is updated to `processed`
- project is ready for embedding and retrieval

## Test
- upload PDF through `/documents/upload`
- verify document status becomes `processed`
- verify chunks store in `document_chunks`

## Related Issue
Closes #9