### PR TITLE
feat: prepare document indexing structure

### DIFF
--- a/db/base.py
+++ b/db/base.py
@@ -3,3 +3,11 @@ from sqlalchemy.orm import DeclarativeBase
 
 class Base(DeclarativeBase):
     pass
+
+
+# 모델 import 등록
+from models.conversation import Conversation  # noqa: F401
+from models.message import Message  # noqa: F401
+from models.document import Document  # noqa: F401
+from models.document_chunk import DocumentChunk  # noqa: F401
+from models.chunk_embedding import ChunkEmbedding  # noqa: F401

--- a/models/chunk_embedding.py
+++ b/models/chunk_embedding.py
@@ -1,0 +1,29 @@
+# models/chunk_embedding.py
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from db.base import Base
+
+
+class ChunkEmbedding(Base):
+    __tablename__ = "chunk_embeddings"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+
+    document_chunk_id: Mapped[int] = mapped_column(
+        ForeignKey("document_chunks.id"),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+
+    embedding_model: Mapped[str] = mapped_column(String, nullable=False)
+    embedding_dimension: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    status: Mapped[str] = mapped_column(String, nullable=False, default="pending")
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=datetime.utcnow
+    )

--- a/models/document.py
+++ b/models/document.py
@@ -14,7 +14,7 @@ class Document(Base):
     stored_filename: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
     file_path: Mapped[str] = mapped_column(String(500), nullable=False, unique=True)
     file_type: Mapped[str] = mapped_column(String(100), nullable=False)
-    status: Mapped[str] = mapped_column(String(50), nullable=False, default="uploaded")
+    status: Mapped[str] = mapped_column(String(50), nullable=False, default="uploaded") # uploaded, processing, processed, indexed, failed
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime,

--- a/repositories/chunk_embedding_repo.py
+++ b/repositories/chunk_embedding_repo.py
@@ -1,0 +1,34 @@
+# repositories/chunk_embedding_repo.py
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from models.chunk_embedding import ChunkEmbedding
+
+
+class ChunkEmbeddingRepository:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def create(
+        self,
+        document_chunk_id: int,
+        embedding_model: str,
+        embedding_dimension: int,
+        status: str = "pending",
+    ) -> ChunkEmbedding:
+        chunk_embedding = ChunkEmbedding(
+            document_chunk_id=document_chunk_id,
+            embedding_model=embedding_model,
+            embedding_dimension=embedding_dimension,
+            status=status,
+        )
+        self.db.add(chunk_embedding)
+        self.db.commit()
+        self.db.refresh(chunk_embedding)
+        return chunk_embedding
+
+    def get_by_chunk_id(self, document_chunk_id: int) -> ChunkEmbedding | None:
+        stmt = select(ChunkEmbedding).where(
+            ChunkEmbedding.document_chunk_id == document_chunk_id
+        )
+        return self.db.scalar(stmt)


### PR DESCRIPTION
## Summary
Prepare the project structure for embedding-based document indexing.

## Changes
- add chunk embedding model
- add chunk embedding repository skeleton
- register chunk embedding model in DB metadata
- prepare document status flow for indexing

## Result
- project is ready for embedding pipeline implementation
- indexing lifecycle can be separated from document processing
- retrieval-related features can be added in the next step

## Related Issue
Closes #12 