### PR TITLE
feat: add chunk embedding model and repository refactor

### DIFF
--- a/models/chunk_embedding.py
+++ b/models/chunk_embedding.py
@@ -1,7 +1,7 @@
 # models/chunk_embedding.py
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String
+from sqlalchemy import DateTime, ForeignKey, Integer, String, JSON
 from sqlalchemy.orm import Mapped, mapped_column
 
 from db.base import Base
@@ -21,6 +21,8 @@ class ChunkEmbedding(Base):
 
     embedding_model: Mapped[str] = mapped_column(String, nullable=False)
     embedding_dimension: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    vector: Mapped[list] = mapped_column(JSON, nullable=True)
 
     status: Mapped[str] = mapped_column(String, nullable=False, default="pending")
 

--- a/repositories/chunk_embedding_repo.py
+++ b/repositories/chunk_embedding_repo.py
@@ -32,3 +32,5 @@ class ChunkEmbeddingRepository:
             ChunkEmbedding.document_chunk_id == document_chunk_id
         )
         return self.db.scalar(stmt)
+    def create_embedding(self, embedding):
+        self.db.add(embedding)

--- a/repositories/document_chunk_repo.py
+++ b/repositories/document_chunk_repo.py
@@ -3,17 +3,22 @@ from sqlalchemy.orm import Session
 
 from models.document_chunk import DocumentChunk
 
+
 class DocumentChunkRepository:
+
+    def __init__(self, db: Session):
+        self.db = db
+
     def create_many(
-            self,
-            db: Session,
-            *,
-            document_id: int,
-            chunks: list[dict],
+        self,
+        *,
+        document_id: int,
+        chunks: list[dict],
     ) -> list[DocumentChunk]:
+
         chunk_objects = [
             DocumentChunk(
-            document_id=document_id,
+                document_id=document_id,
                 chunk_index=chunk["chunk_index"],
                 page_number=chunk.get("page_number"),
                 content=chunk["content"],
@@ -21,22 +26,33 @@ class DocumentChunkRepository:
             for chunk in chunks
         ]
 
-        db.add_all(chunk_objects)
-        db.commit()
+        self.db.add_all(chunk_objects)
+        self.db.commit()
 
         for chunk_obj in chunk_objects:
-            db.refresh(chunk_obj)
+            self.db.refresh(chunk_obj)
 
         return chunk_objects
 
-    def list_by_document_id(self, db: Session, document_id: int) -> list[DocumentChunk]:
+    def list_by_document_id(self, document_id: int) -> list[DocumentChunk]:
         return (
-            db.query(DocumentChunk)
+            self.db.query(DocumentChunk)
             .filter(DocumentChunk.document_id == document_id)
             .order_by(DocumentChunk.chunk_index.asc())
             .all()
         )
 
-    def delete_by_document_id(self, db: Session, document_id: int) -> None:
-        db.query(DocumentChunk).filter(DocumentChunk.document_id == document_id).delete()
-        db.commit()
+    def delete_by_document_id(self, document_id: int) -> None:
+        self.db.query(DocumentChunk).filter(
+            DocumentChunk.document_id == document_id
+        ).delete()
+
+        self.db.commit()
+
+    def get_chunks_by_document_id(self, document_id: int) -> list[DocumentChunk]:
+
+        return (
+            self.db.query(DocumentChunk)
+            .filter(DocumentChunk.document_id == document_id)
+            .all()
+        )

--- a/services/document_service.py
+++ b/services/document_service.py
@@ -13,13 +13,15 @@ from services.chunking_service import ChunkingService
 
 ALLOWED_EXTENSIONS = {".pdf"}
 
-document_repo = DocumentRepository()
-document_chunk_repo = DocumentChunkRepository()
 document_parser_service = DocumentParserService()
 chunking_service = ChunkingService()
 
 
 def upload_document(db: Session, file: UploadFile):
+
+    document_repo = DocumentRepository()
+    document_chunk_repo = DocumentChunkRepository(db)
+
     if not file.filename:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -61,7 +63,6 @@ def upload_document(db: Session, file: UploadFile):
 
         if chunks:
             document_chunk_repo.create_many(
-                db=db,
                 document_id=document.id,
                 chunks=chunks,
             )

--- a/services/embedding_service.py
+++ b/services/embedding_service.py
@@ -1,0 +1,41 @@
+# services/embedding_service.py
+from openai import OpenAI
+from sqlalchemy.orm import Session
+from repositories.document_chunk_repo import DocumentChunkRepository
+from repositories.chunk_embedding_repo import ChunkEmbeddingRepository
+from models.chunk_embedding import ChunkEmbedding
+import os
+
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+class EmbeddingService:
+
+    def __init__(self, db: Session):
+        self.db = db
+        self.chunk_repo = DocumentChunkRepository(db)
+        self.embedding_repo = ChunkEmbeddingRepository(db)
+
+    def generate_embeddings(self, document_id: int):
+
+        chunks = self.chunk_repo.get_chunks_by_document_id(document_id)
+
+        for chunk in chunks:
+
+            response = client.embeddings.create(
+                model="text-embedding-3-small",
+                input=chunk.content
+            )
+
+            vector = response.data[0].embedding
+
+            embedding = ChunkEmbedding(
+                document_chunk_id=chunk.id,
+                embedding_model="text-embedding-3-small",
+                embedding_dimension=len(vector),
+                vector=vector,
+                status="completed"
+            )
+
+            self.embedding_repo.create_embedding(embedding)
+
+        self.db.commit()


### PR DESCRIPTION
## Summary
Add chunk embedding model and refactor repository structure to support embedding generation.

## Changes
- add vector field to ChunkEmbedding model
- update DocumentChunkRepository to use db session via constructor
- update document_service repository initialization
- remove db parameter from create_many calls

## Result
Document processing pipeline now supports storing embedding vectors.
This prepares the system for retrieval and RAG implementation.

Closes #14 